### PR TITLE
Add screaning seat entity to control screenings seat reservation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ The project is currently in the early stages of development. The main features a
 - [x] Create Seat entity
 - [x] Create Seed script to run on app startup to create the available theaters and seats (create CRUD for them in the future)
 - [x] Rename Movie entity to Screening for a better naming and separation of concerns
-- [ ] Create ScreeningSeat entity for managing seat reservations within a screening
+- [x] Create ScreeningSeat entity for managing seat reservations within a screening
+- [ ] Populate the screening seats for a screening on creation
 - [ ] Create endpoint for available seats in a screening
 - [ ] Create endpoint for reserving a seat in a screening
 - [ ] Create a new Movie entity just for the static information about movies available for screening

--- a/src/migrations/1754750850053-migration.ts
+++ b/src/migrations/1754750850053-migration.ts
@@ -1,0 +1,26 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class Migration1754750850053 implements MigrationInterface {
+    name = 'Migration1754750850053'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "screening" RENAME COLUMN "room" TO "theaterId"`);
+        await queryRunner.query(`CREATE TYPE "public"."screeningSeat_status_enum" AS ENUM('AVAILABLE', 'PENDING', 'RESERVED')`);
+        await queryRunner.query(`CREATE TABLE "screeningSeat" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "screeningId" uuid NOT NULL, "rowLabel" character varying NOT NULL, "seatNumber" character varying NOT NULL, "status" "public"."screeningSeat_status_enum" NOT NULL DEFAULT 'AVAILABLE', CONSTRAINT "PK_054bd8b7861183d5ef6554ac366" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`ALTER TABLE "screening" DROP COLUMN "theaterId"`);
+        await queryRunner.query(`ALTER TABLE "screening" ADD "theaterId" uuid NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "screening" ADD CONSTRAINT "FK_bda8523916fec884d0b4ddc6065" FOREIGN KEY ("theaterId") REFERENCES "theater"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "screeningSeat" ADD CONSTRAINT "FK_89e26e93490f8dc8c862e5611c2" FOREIGN KEY ("screeningId") REFERENCES "screening"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "screeningSeat" DROP CONSTRAINT "FK_89e26e93490f8dc8c862e5611c2"`);
+        await queryRunner.query(`ALTER TABLE "screening" DROP CONSTRAINT "FK_bda8523916fec884d0b4ddc6065"`);
+        await queryRunner.query(`ALTER TABLE "screening" DROP COLUMN "theaterId"`);
+        await queryRunner.query(`ALTER TABLE "screening" ADD "theaterId" character varying NOT NULL`);
+        await queryRunner.query(`DROP TABLE "screeningSeat"`);
+        await queryRunner.query(`DROP TYPE "public"."screeningSeat_status_enum"`);
+        await queryRunner.query(`ALTER TABLE "screening" RENAME COLUMN "theaterId" TO "room"`);
+    }
+
+}

--- a/src/modules/screening-seats/database/screening-seat.entity.ts
+++ b/src/modules/screening-seats/database/screening-seat.entity.ts
@@ -1,0 +1,27 @@
+import { BaseEntity, PrimaryGeneratedColumn, Column, ForeignKey, Entity } from 'typeorm';
+import { ScreeningDBEntity } from '../../screenings/database/screening.entity.ts';
+
+enum SCREENING_SEAT_STATUS {
+  AVAILABLE = 'AVAILABLE',
+  PENDING = 'PENDING',
+  RESERVED = 'RESERVED',
+}
+
+@Entity('screeningSeat')
+export class ScreeningSeatDBEntity extends BaseEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'uuid' })
+  @ForeignKey(() => ScreeningDBEntity)
+  screeningId!: string;
+
+  @Column()
+  rowLabel!: string;
+
+  @Column()
+  seatNumber!: string;
+
+  @Column({ type: 'enum', enum: SCREENING_SEAT_STATUS, default: SCREENING_SEAT_STATUS.AVAILABLE })
+  status!: SCREENING_SEAT_STATUS;
+}

--- a/src/modules/screenings/database/screening.entity.ts
+++ b/src/modules/screenings/database/screening.entity.ts
@@ -1,4 +1,5 @@
-import { BaseEntity, Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { BaseEntity, Column, Entity, ForeignKey, PrimaryGeneratedColumn } from 'typeorm';
+import { TheaterDBEntity } from '../../theaters/database/theater.entity.ts';
 
 @Entity('screening')
 export class ScreeningDBEntity extends BaseEntity {
@@ -14,8 +15,9 @@ export class ScreeningDBEntity extends BaseEntity {
   @Column()
   category!: string;
 
-  @Column()
-  room!: string;
+  @Column('uuid')
+  @ForeignKey(() => TheaterDBEntity)
+  theaterId!: string;
 
   @Column()
   startTime!: Date;

--- a/src/modules/screenings/entities/screening.ts
+++ b/src/modules/screenings/entities/screening.ts
@@ -4,7 +4,7 @@ export class Screening {
     public title: string,
     public description: string,
     public category: string,
-    public room: string,
+    public theaterId: string,
     public startTime: Date,
     public endTime: Date,
   ) {}

--- a/src/modules/screenings/http/controllers/create.ts
+++ b/src/modules/screenings/http/controllers/create.ts
@@ -9,14 +9,14 @@ export class CreateScreeningController implements IHttpController {
   constructor(private readonly createScreeningUseCase: CreateScreeningUseCase) {}
 
   async handle(request: Request, response: Response): Promise<void> {
-    const { title, description, category, room, startTime, endTime } = request.body;
+    const { title, description, category, theaterId, startTime, endTime } = request.body;
 
     try {
       const screening = await this.createScreeningUseCase.execute({
         title,
         description,
         category,
-        room,
+        theaterId,
         startTime: new Date(startTime),
         endTime: new Date(endTime),
       });

--- a/src/modules/screenings/repositories/interfaces/screening.repository.ts
+++ b/src/modules/screenings/repositories/interfaces/screening.repository.ts
@@ -1,7 +1,7 @@
 import { Screening } from '../../entities/screening.ts';
 
 export interface IScreeningRepository {
-  findByRoomAndTime(room: string, startTime: Date, endTime: Date): Promise<Screening | null>;
+  findByTheaterIdAndTime(theaterId: string, startTime: Date, endTime: Date): Promise<Screening | null>;
   findAll(): Promise<Screening[]>;
   findById(id: string): Promise<Screening | null>;
   save(screening: Screening): Promise<void>;

--- a/src/modules/screenings/repositories/screening.repository.ts
+++ b/src/modules/screenings/repositories/screening.repository.ts
@@ -4,10 +4,10 @@ import { Screening } from '../entities/screening.ts';
 import { IScreeningRepository } from './interfaces/screening.repository.ts';
 
 export class ScreeningRepository implements IScreeningRepository {
-  async findByRoomAndTime(room: string, startTime: Date, endTime: Date): Promise<Screening | null> {
+  async findByTheaterIdAndTime(theaterId: string, startTime: Date, endTime: Date): Promise<Screening | null> {
     const foundScreening = await ScreeningDBEntity.createQueryBuilder('screening')
       .select()
-      .where('screening.room = :room', { room })
+      .where('screening.theaterId = :theaterId', { theaterId })
       .andWhere(
         new Brackets((qb) => {
           qb.where(
@@ -36,7 +36,7 @@ export class ScreeningRepository implements IScreeningRepository {
       foundScreening.title,
       foundScreening.description,
       foundScreening.category,
-      foundScreening.room,
+      foundScreening.theaterId,
       foundScreening.startTime,
       foundScreening.endTime,
     );
@@ -54,7 +54,7 @@ export class ScreeningRepository implements IScreeningRepository {
       foundScreening.title,
       foundScreening.description,
       foundScreening.category,
-      foundScreening.room,
+      foundScreening.theaterId,
       foundScreening.startTime,
       foundScreening.endTime,
     );
@@ -70,7 +70,7 @@ export class ScreeningRepository implements IScreeningRepository {
           screening.title,
           screening.description,
           screening.category,
-          screening.room,
+          screening.theaterId,
           screening.startTime,
           screening.endTime,
         ),

--- a/src/modules/screenings/use-cases/create.ts
+++ b/src/modules/screenings/use-cases/create.ts
@@ -9,7 +9,7 @@ type Input = {
   title: string;
   description: string;
   category: string;
-  room: string;
+  theaterId: string;
   startTime: Date;
   endTime: Date;
 };
@@ -19,10 +19,10 @@ export class CreateScreeningUseCase {
 
   async execute(input: Input): Promise<Screening> {
     const inputValidationSchema = z.object({
-      title: z.string().min(1, 'Title is required'),
+      title: z.string().min(1, 'title field is required'),
       description: z.string().optional(),
-      category: z.string().min(1, 'Category is required'),
-      room: z.string().min(1, 'Room is required'),
+      category: z.string().min(1, 'category field is required'),
+      theaterId: z.uuid('theaterId field is required'),
       startTime: z.date().refine((date) => !isNaN(date.getTime()), {
         message: 'Start time must be a valid date',
       }),
@@ -41,13 +41,21 @@ export class CreateScreeningUseCase {
       throw new InvalidTimeError();
     }
 
-    const existingScreening = await this.repository.findByRoomAndTime(input.room, input.startTime, input.endTime);
+    const existingScreening = await this.repository.findByTheaterIdAndTime(input.theaterId, input.startTime, input.endTime);
 
     if (existingScreening) {
       throw new AlreadyScheduledMovieError();
     }
 
-    const screening = new Screening(crypto.randomUUID(), input.title, input.description, input.category, input.room, input.startTime, input.endTime);
+    const screening = new Screening(
+      crypto.randomUUID(),
+      input.title,
+      input.description,
+      input.category,
+      input.theaterId,
+      input.startTime,
+      input.endTime,
+    );
 
     await this.repository.save(screening);
 

--- a/src/modules/shared/data-source/data-source.ts
+++ b/src/modules/shared/data-source/data-source.ts
@@ -7,6 +7,7 @@ import { ReservationDBEntity } from '../../reservations/database/reservation.ent
 import { readFileSync } from 'node:fs';
 import { SeatDBEntity } from '../../seats/database/seat.entity.ts';
 import { TheaterDBEntity } from '../../theaters/database/theater.entity.ts';
+import { ScreeningSeatDBEntity } from '../../screening-seats/database/screening-seat.entity.ts';
 
 const appConfig = AppConfigLoader.load();
 
@@ -23,7 +24,7 @@ export const appDataSource = new DataSource({
         ca: readFileSync(appConfig.DB_SSL_CA_PATH, 'utf-8'),
       }
     : false,
-  entities: [UserDBEntity, ScreeningDBEntity, ReservationDBEntity, SeatDBEntity, TheaterDBEntity],
+  entities: [UserDBEntity, ScreeningDBEntity, ReservationDBEntity, SeatDBEntity, TheaterDBEntity, ScreeningSeatDBEntity],
   migrations: [appConfig.DB_MIGRATIONS_PATH],
   logging: true,
 });


### PR DESCRIPTION
This PR adds the screeningSeat entity to control the seats reservation in a given screening. 

It also replaces the room concept in the screening entity with the theaterId, because when a screening is created, it is not attached to a simple room as string, but to a existing theater that must have its existence verified.