### PR TITLE
chore(reservations): add reservation data on its creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The project is currently in the early stages of development. The main features a
 - [x] Add pagination to screenings listing endpoint
 - [x] Add pagination to reservations listing endpoint
 - [x] Add error handling on screening seats listing controller
-- [ ] Return reservation data on its creation
+- [x] Return reservation data on its creation
 - [ ] Remove the empty object from the responses where no data is returned
 - [ ] Review the reservation status
 

--- a/src/migrations/1756083122992-migration.ts
+++ b/src/migrations/1756083122992-migration.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class Migration1756083122992 implements MigrationInterface {
+    name = 'Migration1756083122992'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "reservation" DROP CONSTRAINT "FK_825611e3ea7b9d8c66de16ddac0"`);
+        await queryRunner.query(`ALTER TABLE "reservation" ADD CONSTRAINT "UQ_825611e3ea7b9d8c66de16ddac0" UNIQUE ("screeningSeatId")`);
+        await queryRunner.query(`ALTER TABLE "reservation" ADD CONSTRAINT "FK_825611e3ea7b9d8c66de16ddac0" FOREIGN KEY ("screeningSeatId") REFERENCES "screeningSeat"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "reservation" DROP CONSTRAINT "FK_825611e3ea7b9d8c66de16ddac0"`);
+        await queryRunner.query(`ALTER TABLE "reservation" DROP CONSTRAINT "UQ_825611e3ea7b9d8c66de16ddac0"`);
+        await queryRunner.query(`ALTER TABLE "reservation" ADD CONSTRAINT "FK_825611e3ea7b9d8c66de16ddac0" FOREIGN KEY ("screeningSeatId") REFERENCES "screeningSeat"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+}

--- a/src/modules/reservations/database/reservation.entity.ts
+++ b/src/modules/reservations/database/reservation.entity.ts
@@ -1,4 +1,4 @@
-import { BaseEntity, Column, CreateDateColumn, Entity, ForeignKey, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';
+import { BaseEntity, Column, CreateDateColumn, Entity, ForeignKey, JoinColumn, OneToOne, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';
 import { ScreeningSeatDBEntity } from '../../screenings/database/screening-seat.entity.ts';
 import { UserDBEntity } from '../../users/database/user.entity.ts';
 
@@ -17,9 +17,9 @@ export class ReservationDBEntity extends BaseEntity {
   @ForeignKey(() => UserDBEntity)
   userId!: string;
 
-  @Column('uuid')
-  @ForeignKey(() => ScreeningSeatDBEntity)
-  screeningSeatId!: string;
+  @OneToOne(() => ScreeningSeatDBEntity, { nullable: false })
+  @JoinColumn()
+  screeningSeat!: ScreeningSeatDBEntity;
 
   @Column({ type: 'enum', enum: RESERVATION_STATUS, default: RESERVATION_STATUS.PENDING })
   status!: RESERVATION_STATUS;

--- a/src/modules/reservations/dtos/reservation.dto.ts
+++ b/src/modules/reservations/dtos/reservation.dto.ts
@@ -1,0 +1,14 @@
+import { RESERVATION_STATUS } from '../database/reservation.entity.ts';
+import { Reservation } from '../entities/reservation.ts';
+
+export type ReservationDTO = {
+  id: string;
+  seat: string;
+  status: RESERVATION_STATUS;
+};
+
+export const mapReservationToDTO = ({ id, status, screeningSeat: { rowLabel, seatNumber } }: Reservation): ReservationDTO => ({
+  id,
+  seat: rowLabel + seatNumber,
+  status,
+});

--- a/src/modules/reservations/entities/reservation.ts
+++ b/src/modules/reservations/entities/reservation.ts
@@ -1,10 +1,11 @@
+import { ScreeningSeat } from '../../screenings/entities/screening-seat.ts';
 import { RESERVATION_STATUS } from '../database/reservation.entity.ts';
 
 export class Reservation {
   constructor(
     public id: string,
     public userId: string,
-    public screeningSeatId: string,
+    public screeningSeat: ScreeningSeat,
     public status: RESERVATION_STATUS,
   ) {}
 }

--- a/src/modules/reservations/http/controllers/create.ts
+++ b/src/modules/reservations/http/controllers/create.ts
@@ -1,24 +1,25 @@
 import { InputValidationError } from '../../../shared/errors/input-validation.ts';
 import { IHttpControllerV2, THttpRequest, THttpResponse } from '../../../shared/interfaces/http/controller.ts';
-import { Reservation } from '../../entities/reservation.ts';
+import { mapReservationToDTO, ReservationDTO } from '../../dtos/reservation.dto.ts';
 import { InvalidScreeningSeatIdError } from '../../errors/invalid-screening-id.ts';
 import { SeatAlreadyReservedError } from '../../errors/seat-already-reserved.ts';
 import { CreateReservationUseCase } from '../../use-cases/create.ts';
 
-export class CreateReservationController implements IHttpControllerV2<Reservation> {
+export class CreateReservationController implements IHttpControllerV2<ReservationDTO> {
   constructor(private readonly createReservationUseCase: CreateReservationUseCase) {}
 
-  async handle(request: THttpRequest): Promise<THttpResponse<Reservation>> {
+  async handle(request: THttpRequest): Promise<THttpResponse<ReservationDTO>> {
     try {
       const { screeningSeatId } = request.body;
 
-      await this.createReservationUseCase.execute({
+      const reservation = await this.createReservationUseCase.execute({
         userId: request.user!.id,
         screeningSeatId,
       });
 
       return {
         status: 201,
+        data: mapReservationToDTO(reservation),
       };
     } catch (error) {
       if (error instanceof SeatAlreadyReservedError || error instanceof InvalidScreeningSeatIdError) {

--- a/src/modules/reservations/http/controllers/list.ts
+++ b/src/modules/reservations/http/controllers/list.ts
@@ -1,11 +1,11 @@
-import { IHttpControllerV2, THttpRequest, THttpResponse } from '../../../shared/interfaces/http/controller';
-import { IReservationRepository } from '../../repositories/interfaces/reservation.repository';
-import { Reservation } from '../../entities/reservation';
+import { IHttpControllerV2, THttpRequest, THttpResponse } from '../../../shared/interfaces/http/controller.ts';
+import { IReservationRepository } from '../../repositories/interfaces/reservation.repository.ts';
 import z from 'zod';
+import { mapReservationToDTO, ReservationDTO } from '../../dtos/reservation.dto.ts';
 
-export class ListReservationsController implements IHttpControllerV2<Reservation[]> {
+export class ListReservationsController implements IHttpControllerV2<ReservationDTO> {
   constructor(private reservationRepository: IReservationRepository) {}
-  async handle(request: THttpRequest): Promise<THttpResponse<Reservation[]>> {
+  async handle(request: THttpRequest): Promise<THttpResponse<ReservationDTO>> {
     try {
       if (!request.user) {
         return {
@@ -31,7 +31,7 @@ export class ListReservationsController implements IHttpControllerV2<Reservation
 
       return {
         status: 200,
-        data,
+        data: data.map((reservation) => mapReservationToDTO(reservation)),
         meta: {
           hasNext,
           nextCursor,

--- a/src/modules/reservations/repositories/reservation.repository.ts
+++ b/src/modules/reservations/repositories/reservation.repository.ts
@@ -33,6 +33,7 @@ export class ReservationRepository implements IReservationRepository {
       .select()
       .where('reservation.userId = :userId', { userId })
       .orderBy('reservation.createdAt', 'DESC')
+      .leftJoinAndSelect('reservation.screeningSeat', 'screeningSeat')
       .limit(limitWithNextPageFirstElement);
 
     if (cursor) {
@@ -63,7 +64,11 @@ export class ReservationRepository implements IReservationRepository {
   }
 
   async findById(reservationId: string): Promise<Reservation | null> {
-    return ReservationDBEntity.createQueryBuilder('reservation').select().where('reservation.id = :reservationId', { reservationId }).getOne();
+    return ReservationDBEntity.createQueryBuilder('reservation')
+      .select()
+      .leftJoinAndSelect('reservation.screeningSeat', 'screeningSeat')
+      .where('reservation.id = :reservationId', { reservationId })
+      .getOne();
   }
 
   async updateStatusById(reservationId: string, status: RESERVATION_STATUS): Promise<void> {

--- a/src/modules/reservations/use-cases/cancel.ts
+++ b/src/modules/reservations/use-cases/cancel.ts
@@ -37,7 +37,7 @@ export class CancelReservationUseCase {
       throw new ReservationDoesNotExistError();
     }
 
-    const screening = await this.screeningRepository.findScreeningByScreeningSeatId(reservation.screeningSeatId);
+    const screening = await this.screeningRepository.findScreeningByScreeningSeatId(reservation.screeningSeat.id);
 
     if (!screening) {
       throw new ScreeningDoesNotExistError();
@@ -51,7 +51,7 @@ export class CancelReservationUseCase {
       throw new CancelingOperationOutOfRange();
     }
 
-    await this.screeningRepository.updateScreeningSeatStatusById(reservation.screeningSeatId, SCREENING_SEAT_STATUS.AVAILABLE);
+    await this.screeningRepository.updateScreeningSeatStatusById(reservation.screeningSeat.id, SCREENING_SEAT_STATUS.AVAILABLE);
 
     await this.reservationRepository.updateStatusById(reservationId, RESERVATION_STATUS.CANCELED);
   }

--- a/src/modules/reservations/use-cases/create.ts
+++ b/src/modules/reservations/use-cases/create.ts
@@ -19,7 +19,7 @@ export class CreateReservationUseCase {
     private readonly screeningRepository: IScreeningRepository,
   ) {}
 
-  async execute(input: Input): Promise<void> {
+  async execute(input: Input): Promise<Reservation> {
     const inputValidationSchema = z.object({
       screeningSeatId: z.uuid('Invalid screening seat ID format'),
     });
@@ -42,10 +42,12 @@ export class CreateReservationUseCase {
       throw new SeatAlreadyReservedError();
     }
 
-    const reservation = new Reservation(crypto.randomUUID(), input.userId, screeningSeatId, RESERVATION_STATUS.CONFIRMED);
+    const reservation = new Reservation(crypto.randomUUID(), input.userId, existingScreeningSeat, RESERVATION_STATUS.CONFIRMED);
 
     await this.screeningRepository.updateScreeningSeatStatusById(screeningSeatId, SCREENING_SEAT_STATUS.RESERVED);
 
     await this.reservationRepository.save(reservation);
+
+    return reservation;
   }
 }


### PR DESCRIPTION
Changes in this PR:

- Created the Reservation DTO to return the Reservation data in a more controlled way to the client instead of just returning the play entity, which was an ugly object with no control over the fields (I know that it should be done this way since the beginning, but I'm taking the approach of evolving the codebase over the time).
- Replaced the screeningSeatId field on the Reservation entity with the whole screeningSeat entity, as it is needed to retrieve the seat data to return to the client with the reservation data.
- Created the mapper to map the reservation entity to the DTO, both to not leak unwanted fields and format the objects in a friendly interface.
- Made some changes in the repository to lazy load the screeningSeat entity, using the leftJoinAndSelect() method from the typeorm QueryBuilder.