### PR TITLE
[refactor] Increase reservations dto details and improve queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The project is currently in the early stages of development. The main features a
   - [x] ListScreeningSeatsController
   - [x] ListScreeningsController
   - [x] UsersLoginController
-- [ ] Add the screening information on the reservation dto, for a better experience to the clients. When we get the reservations, we already want to see the screening info.
+- [x] Add the screening information on the reservation dto, for a better experience to the clients. When we get the reservations, we already want to see the screening info.
 - [x] Add lazy relation loading on the screening seat Entity to return the screening data as needed using typeorm
 
 ## Improvements

--- a/src/modules/reservations/dtos/reservation.dto.ts
+++ b/src/modules/reservations/dtos/reservation.dto.ts
@@ -3,12 +3,26 @@ import { Reservation } from '../database/reservation.entity.ts';
 
 export type ReservationDTO = {
   id: string;
+  screening: {
+    id: string;
+    movieTitle: string;
+    theaterNameName: string;
+    startTime: Date;
+    endTime: Date;
+  };
   seat: string;
   status: RESERVATION_STATUS;
 };
 
-export const mapReservationToDTO = ({ id, status, screeningSeat: { rowLabel, seatNumber } }: Reservation): ReservationDTO => ({
+export const mapReservationToDTO = ({ id, status, screeningSeat: { rowLabel, seatNumber, screening } }: Reservation): ReservationDTO => ({
   id,
+  screening: {
+    id: screening.id,
+    movieTitle: screening.movie.title,
+    theaterNameName: screening.theater.name,
+    startTime: screening.startTime,
+    endTime: screening.endTime,
+  },
   seat: rowLabel + seatNumber,
   status,
 });

--- a/src/modules/reservations/http/controllers/create.ts
+++ b/src/modules/reservations/http/controllers/create.ts
@@ -22,6 +22,8 @@ export class CreateReservationController implements IHttpControllerV2<Reservatio
         data: mapReservationToDTO(reservation),
       };
     } catch (error) {
+      console.error('Error during reservation listing:', error);
+
       if (error instanceof SeatAlreadyReservedError || error instanceof InvalidScreeningSeatIdError) {
         return {
           status: 409,

--- a/src/modules/reservations/repositories/reservation.repository.ts
+++ b/src/modules/reservations/repositories/reservation.repository.ts
@@ -3,7 +3,7 @@ import { appDataSource } from '../../shared/data-source/data-source.ts';
 import { decodeCursor, encodeCursor } from '../../shared/pagination/helpers.ts';
 import { IPaginationParams, TPaginationResponse } from '../../shared/pagination/types.ts';
 import { RESERVATION_STATUS, Reservation } from '../database/reservation.entity.ts';
-import { IReservationRepository } from './interfaces/reservation.repository';
+import { IReservationRepository } from './interfaces/reservation.repository.ts';
 
 export class ReservationRepository implements IReservationRepository {
   constructor(private appConfig: AppConfig) {}
@@ -12,6 +12,10 @@ export class ReservationRepository implements IReservationRepository {
     return appDataSource
       .createQueryBuilder(Reservation, 'reservation')
       .select()
+      .leftJoinAndSelect('reservation.screeningSeat', 'screeningSeat')
+      .leftJoinAndSelect('screeningSeat.screening', 'screening')
+      .leftJoinAndSelect('screening.movie', 'movie')
+      .leftJoinAndSelect('screening.theater', 'theater')
       .where('reservation.screeningId = :screeningId', { screeningId })
       .andWhere('reservation.seatCode = :seatCode', { seatCode })
       .getOne();
@@ -34,9 +38,12 @@ export class ReservationRepository implements IReservationRepository {
     const reservationsQuery = appDataSource
       .createQueryBuilder(Reservation, 'reservation')
       .select()
+      .leftJoinAndSelect('reservation.screeningSeat', 'screeningSeat')
+      .leftJoinAndSelect('screeningSeat.screening', 'screening')
+      .leftJoinAndSelect('screening.movie', 'movie')
+      .leftJoinAndSelect('screening.theater', 'theater')
       .where('reservation.userId = :userId', { userId })
       .orderBy('reservation.createdAt', 'DESC')
-      .leftJoinAndSelect('reservation.screeningSeat', 'screeningSeat')
       .limit(limitWithNextPageFirstElement);
 
     if (cursor) {
@@ -71,6 +78,9 @@ export class ReservationRepository implements IReservationRepository {
       .createQueryBuilder(Reservation, 'reservation')
       .select()
       .leftJoinAndSelect('reservation.screeningSeat', 'screeningSeat')
+      .leftJoinAndSelect('screeningSeat.screening', 'screening')
+      .leftJoinAndSelect('screening.movie', 'movie')
+      .leftJoinAndSelect('screening.theater', 'theater')
       .where('reservation.id = :reservationId', { reservationId })
       .getOne();
   }

--- a/src/modules/screenings/repositories/screening.repository.ts
+++ b/src/modules/screenings/repositories/screening.repository.ts
@@ -162,7 +162,15 @@ export class ScreeningRepository implements IScreeningRepository {
   }
 
   async findSeatByScreeningSeatId(screeningSeatId: string): Promise<ScreeningSeat | null> {
-    const foundScreeningSeat = await appDataSource.getRepository(ScreeningSeat).findOne({ where: { id: screeningSeatId } });
+    const foundScreeningSeat = await appDataSource.getRepository(ScreeningSeat).findOne({
+      where: { id: screeningSeatId },
+      relations: {
+        screening: {
+          movie: true,
+          theater: true,
+        },
+      },
+    });
 
     if (!foundScreeningSeat) return null;
 


### PR DESCRIPTION
Changes in this PR:

- Improved the reservations DTO to include screening, movie, and theater info, making the response more complete, and removing the need to make more requests to get the missing data. If the client only wants the reservation ID, it can be too much information, and the payload can become heavy. Currently, it is not a requirement. In this case, in the future, we could have a GraphQL API or another lighter endpoint with just the IDs.