### PR TITLE
[fix] Multiple reservations for same seat

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -58,3 +58,4 @@ This document tracks the **detailed technical progress** of the project. The REA
   - [x] Seats
   - [x] Theaters
   - [x] Users
+- [x] Allow multiple reservations to be made to the same screening seat, since only one has the confirmed status

--- a/package.json
+++ b/package.json
@@ -6,8 +6,10 @@
   "scripts": {
     "build": "swc src --out-dir dist",
     "build:ci": "tsc && npm run build",
+    "build:dev": "npm run build -- --watch --source-maps true",
     "check-types": "tsc --noEmit",
     "start:dev": "nodemon dist/src/index.js",
+    "start:dev:inspect": "nodemon --inspect dist/src/index.js",
     "start:prod": "npm run migration:run:prod && node dist/src/index.js",
     "format": "prettier --write .",
     "lint": "eslint . ",

--- a/src/__tests__/e2e/http/reservations/cancel.ts
+++ b/src/__tests__/e2e/http/reservations/cancel.ts
@@ -1,0 +1,79 @@
+import request from 'supertest';
+import { createApp } from '../../../../app.ts';
+import { Express } from 'express';
+import { appDataSource } from '../../../../modules/shared/data-source/data-source.ts';
+import { theatersSeed } from '../../../../modules/shared/seed/theaters.ts';
+import { getAdminUserToken, getRegularUserToken } from '../utils/login.ts';
+import { Movie } from '../../../../modules/movies/database/movie.entity.ts';
+import { Screening } from '../../../../modules/screenings/database/screening.entity.ts';
+import { ScreeningSeat } from '../../../../modules/screenings/database/screening-seat.entity.ts';
+import { Reservation } from '../../../../modules/reservations/database/reservation.entity.ts';
+
+describe('POST /reservations - Cancel reservation', () => {
+  let testingApp: Express;
+  let adminUserToken: string;
+  let regularUserToken: string;
+  let screeningId: string;
+  let screeningSeatId: string;
+
+  beforeAll(async () => {
+    jest.useFakeTimers({ doNotFake: ['nextTick', 'setImmediate'] });
+    jest.setSystemTime(new Date(2025, 7, 19));
+
+    testingApp = createApp();
+    await appDataSource.initialize();
+    await appDataSource.getRepository(Reservation).deleteAll();
+    await appDataSource.getRepository(ScreeningSeat).deleteAll();
+    await appDataSource.getRepository(Screening).deleteAll();
+    await appDataSource.getRepository(Movie).deleteAll();
+
+    adminUserToken = await getAdminUserToken(testingApp);
+
+    regularUserToken = await getRegularUserToken(testingApp);
+
+    const movieResponse = await request(testingApp).post('/movies').set('authorization', `Bearer ${adminUserToken}`).send({
+      title: 'Cars',
+      description: 'The story of Lightning McQueen, a race car who ends up in a small town and learns valuable life lessons.',
+      category: 'animation',
+    });
+
+    const screeningResponse = await request(testingApp).post('/screenings').set('authorization', `Bearer ${adminUserToken}`).send({
+      movieId: movieResponse.body.data.id,
+      theaterId: theatersSeed[0].id,
+      startTime: '2025-08-21T20:00',
+      endTime: '2025-08-21T22:00',
+    });
+
+    screeningId = screeningResponse.body.data.id;
+
+    const screeningSeats = await request(testingApp)
+      .get(`/screenings/${screeningId}/seats`)
+      .set('authorization', `Bearer ${regularUserToken}`)
+      .send();
+
+    screeningSeatId = screeningSeats.body.data[0].id;
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  it('should cancel a reservation successfully', async () => {
+    const {
+      body: { data: createdReservation },
+    } = await request(testingApp).post('/reservations').set('authorization', `Bearer ${regularUserToken}`).send({
+      screeningSeatId,
+    });
+
+    const response = await request(testingApp)
+      .delete(`/reservations/${createdReservation.id}`)
+      .set('authorization', `Bearer ${regularUserToken}`)
+      .send();
+
+    expect(response.status).toBe(204);
+  });
+
+  it.todo('should return the reservation status as canceled after canceling the reservation');
+
+  it.todo('should return the screening seat status as available after canceling the reservation');
+});

--- a/src/__tests__/e2e/http/reservations/create.ts
+++ b/src/__tests__/e2e/http/reservations/create.ts
@@ -4,6 +4,10 @@ import { Express } from 'express';
 import { appDataSource } from '../../../../modules/shared/data-source/data-source.ts';
 import { theatersSeed } from '../../../../modules/shared/seed/theaters.ts';
 import { getAdminUserToken, getRegularUserToken } from '../utils/login.ts';
+import { Movie } from '../../../../modules/movies/database/movie.entity.ts';
+import { ScreeningSeat } from '../../../../modules/screenings/database/screening-seat.entity.ts';
+import { Screening } from '../../../../modules/screenings/database/screening.entity.ts';
+import { Reservation } from '../../../../modules/reservations/database/reservation.entity.ts';
 
 describe('POST /reservations - Create reservation', () => {
   let testingApp: Express;
@@ -14,6 +18,10 @@ describe('POST /reservations - Create reservation', () => {
   beforeAll(async () => {
     testingApp = createApp();
     await appDataSource.initialize();
+    await appDataSource.getRepository(Reservation).deleteAll();
+    await appDataSource.getRepository(ScreeningSeat).deleteAll();
+    await appDataSource.getRepository(Screening).deleteAll();
+    await appDataSource.getRepository(Movie).deleteAll();
 
     adminUserToken = await getAdminUserToken(testingApp);
 

--- a/src/migrations/1756949397994-migration.ts
+++ b/src/migrations/1756949397994-migration.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class Migration1756949397994 implements MigrationInterface {
+    name = 'Migration1756949397994'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "reservation" DROP CONSTRAINT "FK_825611e3ea7b9d8c66de16ddac0"`);
+        await queryRunner.query(`ALTER TABLE "reservation" DROP CONSTRAINT "UQ_825611e3ea7b9d8c66de16ddac0"`);
+        await queryRunner.query(`CREATE UNIQUE INDEX "unique_reserved_seat" ON "reservation" ("screeningSeatId") WHERE status = 'CONFIRMED'`);
+        await queryRunner.query(`ALTER TABLE "reservation" ADD CONSTRAINT "FK_825611e3ea7b9d8c66de16ddac0" FOREIGN KEY ("screeningSeatId") REFERENCES "screeningSeat"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "reservation" DROP CONSTRAINT "FK_825611e3ea7b9d8c66de16ddac0"`);
+        await queryRunner.query(`DROP INDEX "public"."unique_reserved_seat"`);
+        await queryRunner.query(`ALTER TABLE "reservation" ADD CONSTRAINT "UQ_825611e3ea7b9d8c66de16ddac0" UNIQUE ("screeningSeatId")`);
+        await queryRunner.query(`ALTER TABLE "reservation" ADD CONSTRAINT "FK_825611e3ea7b9d8c66de16ddac0" FOREIGN KEY ("screeningSeatId") REFERENCES "screeningSeat"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+}

--- a/src/modules/reservations/database/reservation.entity.ts
+++ b/src/modules/reservations/database/reservation.entity.ts
@@ -1,4 +1,4 @@
-import { Column, CreateDateColumn, Entity, ForeignKey, JoinColumn, OneToOne, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';
+import { Column, CreateDateColumn, Entity, ForeignKey, Index, JoinColumn, ManyToOne, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';
 import { ScreeningSeat } from '../../screenings/database/screening-seat.entity.ts';
 import { User } from '../../users/database/user.entity.ts';
 
@@ -9,6 +9,7 @@ export enum RESERVATION_STATUS {
 }
 
 @Entity('reservation')
+@Index('unique_reserved_seat', ['screeningSeat'], { unique: true, where: `status = '${RESERVATION_STATUS.CONFIRMED}'` })
 export class Reservation {
   @PrimaryGeneratedColumn('uuid')
   id!: string;
@@ -17,7 +18,7 @@ export class Reservation {
   @ForeignKey(() => User)
   userId!: string;
 
-  @OneToOne(() => ScreeningSeat, { nullable: false })
+  @ManyToOne(() => ScreeningSeat, { nullable: false, cascade: true })
   @JoinColumn()
   screeningSeat!: ScreeningSeat;
 

--- a/src/modules/reservations/repositories/reservation.repository.ts
+++ b/src/modules/reservations/repositories/reservation.repository.ts
@@ -27,10 +27,7 @@ export class ReservationRepository implements IReservationRepository {
   }
 
   async save(reservation: Reservation): Promise<void> {
-    appDataSource.getRepository(Reservation).upsert(reservation, {
-      conflictPaths: ['id'],
-      skipUpdateIfNoValuesChanged: true,
-    });
+    await appDataSource.getRepository(Reservation).save(reservation);
   }
 
   async findAllByUserId(

--- a/src/modules/reservations/use-cases/cancel.ts
+++ b/src/modules/reservations/use-cases/cancel.ts
@@ -57,8 +57,9 @@ export class CancelReservationUseCase {
       throw new CancelingOperationOutOfRange();
     }
 
-    await this.screeningRepository.updateScreeningSeatStatusById(reservation.screeningSeat.id, SCREENING_SEAT_STATUS.AVAILABLE);
+    reservation.status = RESERVATION_STATUS.CANCELED;
+    reservation.screeningSeat.status = SCREENING_SEAT_STATUS.AVAILABLE;
 
-    await this.reservationRepository.updateStatusById(reservationId, RESERVATION_STATUS.CANCELED);
+    await this.reservationRepository.save(reservation);
   }
 }

--- a/src/modules/reservations/use-cases/create.ts
+++ b/src/modules/reservations/use-cases/create.ts
@@ -48,9 +48,9 @@ export class CreateReservationUseCase {
       throw new SeatAlreadyReservedError();
     }
 
-    const reservation = Reservation.create(input.userId, existingScreeningSeat, RESERVATION_STATUS.CONFIRMED);
+    existingScreeningSeat.status = SCREENING_SEAT_STATUS.RESERVED;
 
-    await this.screeningRepository.updateScreeningSeatStatusById(screeningSeatId, SCREENING_SEAT_STATUS.RESERVED);
+    const reservation = Reservation.create(input.userId, existingScreeningSeat, RESERVATION_STATUS.CONFIRMED);
 
     await this.reservationRepository.save(reservation);
 

--- a/src/modules/screenings/database/screening.entity.ts
+++ b/src/modules/screenings/database/screening.entity.ts
@@ -14,10 +14,10 @@ export class Screening {
   @ManyToOne(() => Theater, { nullable: false })
   theater!: Theater;
 
-  @Column()
+  @Column('timestamp')
   startTime!: Date;
 
-  @Column()
+  @Column('timestamp')
   endTime!: Date;
 
   static create(movie: Movie, theater: Theater, startTime: Date, endTime: Date): Screening {


### PR DESCRIPTION
Changes in this PR:

- Allowed multiple reservations for the same seat, but enforced only one with the confirmed status.
- Added end-to-end tests to guarantee the canceling endpoint is working as intended.