### PR TITLE
[feat] Read screening seat

### DIFF
--- a/src/__tests__/e2e/http/reservations/cancel.ts
+++ b/src/__tests__/e2e/http/reservations/cancel.ts
@@ -6,7 +6,7 @@ import { theatersSeed } from '../../../../modules/shared/seed/theaters.ts';
 import { getAdminUserToken, getRegularUserToken } from '../utils/login.ts';
 import { Movie } from '../../../../modules/movies/database/movie.entity.ts';
 import { Screening } from '../../../../modules/screenings/database/screening.entity.ts';
-import { ScreeningSeat } from '../../../../modules/screenings/database/screening-seat.entity.ts';
+import { SCREENING_SEAT_STATUS, ScreeningSeat } from '../../../../modules/screenings/database/screening-seat.entity.ts';
 import { Reservation, RESERVATION_STATUS } from '../../../../modules/reservations/database/reservation.entity.ts';
 
 describe('POST /reservations - Cancel reservation', () => {
@@ -89,5 +89,19 @@ describe('POST /reservations - Cancel reservation', () => {
     expect(deleteReservation.status).toBe(RESERVATION_STATUS.CANCELED);
   });
 
-  it.todo('should return the screening seat status as available after canceling the reservation');
+  it('should return the screening seat status as available after canceling the reservation', async () => {
+    const {
+      body: { data: createdReservation },
+    } = await request(testingApp).post('/reservations').set('authorization', `Bearer ${regularUserToken}`).send({
+      screeningSeatId,
+    });
+
+    await request(testingApp).delete(`/reservations/${createdReservation.id}`).set('authorization', `Bearer ${regularUserToken}`).send();
+
+    const {
+      body: { data: screeningSeat },
+    } = await request(testingApp).get(`/seats/${screeningSeatId}`).set('authorization', `Bearer ${regularUserToken}`).send();
+
+    expect(screeningSeat.status).toBe(SCREENING_SEAT_STATUS.AVAILABLE);
+  });
 });

--- a/src/app.ts
+++ b/src/app.ts
@@ -19,6 +19,7 @@ import { expressHttpControllerAdapter } from './modules/shared/external/express/
 import { Container } from 'inversify';
 import { createDependenciesContainer } from './modules/shared/dependencies/create-dependencies-container.ts';
 import { ReadReservationController } from './modules/reservations/http/controllers/read.ts';
+import { ReadScreeningSeatController } from './modules/screenings/http/controllers/read-screening-seat.ts';
 
 const appConfig = AppConfigLoader.load();
 
@@ -84,6 +85,13 @@ export function createApp() {
     expressRequiredPermissionsMiddleware(['screenings:read']),
     expressAuthMiddleware(new JWTTokenValidator(appConfig)),
     expressHttpControllerAdapter(container.get(ListScreeningSeatsController)),
+  );
+
+  app.get(
+    '/seats/:screeningSeatId',
+    expressRequiredPermissionsMiddleware(['screenings:read']),
+    expressAuthMiddleware(new JWTTokenValidator(appConfig)),
+    expressHttpControllerAdapter(container.get(ReadScreeningSeatController)),
   );
 
   app.post(

--- a/src/modules/screenings/dependencies/create-dependencies-container.ts
+++ b/src/modules/screenings/dependencies/create-dependencies-container.ts
@@ -4,12 +4,14 @@ import { CreateScreeningController } from '../http/controllers/create.ts';
 import { ListScreeningSeatsController } from '../http/controllers/list-screening-seats.ts';
 import { ListScreeningsController } from '../http/controllers/list-screenings.ts';
 import { CreateScreeningUseCase } from '../use-cases/create.ts';
+import { ReadScreeningSeatController } from '../http/controllers/read-screening-seat.ts';
 
 export function createDependenciesContainer(container: Container): Container {
   // Controllers
   container.bind(CreateScreeningController).toSelf();
   container.bind(ListScreeningSeatsController).toSelf();
   container.bind(ListScreeningsController).toSelf();
+  container.bind(ReadScreeningSeatController).toSelf();
 
   // Use Cases
   container.bind(CreateScreeningUseCase).toSelf();

--- a/src/modules/screenings/http/controllers/read-screening-seat.ts
+++ b/src/modules/screenings/http/controllers/read-screening-seat.ts
@@ -1,0 +1,51 @@
+import z from 'zod';
+import { IHttpControllerV2, THttpRequest, THttpResponse } from '../../../shared/interfaces/http/controller.ts';
+import type { IScreeningRepository } from '../../repositories/interfaces/screening.repository.ts';
+import { mapScreeningSeatToDTO, ScreeningSeatDTO } from '../../dtos/screening-seat.dto.ts';
+import type { ILogger } from '../../../shared/logger/interfaces/logger.ts';
+import { inject, injectable } from 'inversify';
+import { ScreeningRepository } from '../../repositories/screening.repository.ts';
+import { WinstonLogger } from '../../../shared/logger/winston-logger.ts';
+
+@injectable()
+export class ReadScreeningSeatController implements IHttpControllerV2<ScreeningSeatDTO> {
+  constructor(
+    @inject(ScreeningRepository)
+    private readonly repository: IScreeningRepository,
+    @inject(WinstonLogger)
+    private readonly logger: ILogger,
+  ) {}
+
+  async handle(request: THttpRequest): Promise<THttpResponse<ScreeningSeatDTO>> {
+    try {
+      const requestParamsSchema = z.object({
+        screeningSeatId: z.uuid(),
+      });
+
+      const { success: isValid, data: parsedParams } = requestParamsSchema.safeParse(request.params);
+
+      if (!isValid) {
+        return {
+          status: 400,
+          errors: ['Invalid query parameters'],
+        };
+      }
+
+      const screeningSeat = await this.repository.findSeatByScreeningSeatId(parsedParams.screeningSeatId);
+
+      if (!screeningSeat) {
+        return {
+          status: 404,
+        };
+      }
+
+      return {
+        status: 200,
+        data: mapScreeningSeatToDTO(screeningSeat),
+      };
+    } catch (error) {
+      this.logger.error('Error during screening seats listing:', { error });
+      return { status: 500 };
+    }
+  }
+}


### PR DESCRIPTION
Changes in this PR:

- Added the read screening seat endpoint
- Added the e2e test to guarantee that the canceled screening seat will have the "available" status after reservation cancellation.