### PR TITLE
[fix] Express generic error handler

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -37,6 +37,12 @@ export function createApp() {
 
   app.use(reservationsRouter(container, appConfig));
 
+  // Generic handler for not-found routes (404)
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  app.use((req: Request, res: Response, _next: NextFunction) => {
+    res.status(404).send('Not Found');
+  });
+
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   app.use((err: unknown, _req: Request, res: Response, _next: NextFunction) => {
     if (err instanceof Error) {

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,4 @@
-import express, { Request, Response } from 'express';
+import express, { NextFunction, Request, Response } from 'express';
 import { AppConfigLoader } from './modules/shared/configs/app-config.ts';
 import { Container } from 'inversify';
 import { createDependenciesContainer } from './modules/shared/dependencies/create-dependencies-container.ts';
@@ -37,7 +37,8 @@ export function createApp() {
 
   app.use(reservationsRouter(container, appConfig));
 
-  app.use((err: unknown, req: Request, res: Response) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  app.use((err: unknown, _req: Request, res: Response, _next: NextFunction) => {
     if (err instanceof Error) {
       console.error(err.stack);
     } else {


### PR DESCRIPTION
Changes in this PR:

- Fixed the error "res.status is not a function" that was happening because of missing argument to the express generic error handler.
- Added a generic handler for not found routes.